### PR TITLE
Add interactive Zenn article CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # zenn-articles
 
+## 対話式CLIで記事を作成する
+
+```bash
+cd ~/projects_private/zenn-articles
+npm run article:new
+```
+
+質問に答えると、`articles/`配下にZenn用のMarkdownファイルが作成されます。
+emojiは番号で選択でき、記事作成後は自動で`npx zenn preview`が起動して、作成した記事ページがブラウザで開きます。
+Zenn CLI固有のコマンドやオプションは、このラッパーCLIの内側に隠しています。
+
 ## 記事の雛形からサーバーの起動まで実行
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test",
+    "article:new": "node ./scripts/create-article.mjs",
+    "new": "node ./scripts/create-article.mjs"
   },
   "repository": {
     "type": "git",
@@ -19,5 +21,8 @@
   "homepage": "https://github.com/beginerbeginer/zenn-articles#readme",
   "devDependencies": {
     "zenn-cli": "^0.4.8"
+  },
+  "bin": {
+    "article": "./scripts/create-article.mjs"
   }
 }

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import net from "node:net";
+import path from "node:path";
+import process from "node:process";
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import { pathToFileURL } from "node:url";
+
+const ARTICLE_DIR = "articles";
+const DEFAULT_TYPE = "tech";
+const PREVIEW_PORT = 8000;
+const PREVIEW_HOST = "localhost";
+const EMOJI_CHOICES = [
+  { emoji: "📝", label: "メモ・記事" },
+  { emoji: "💡", label: "アイデア" },
+  { emoji: "🚀", label: "リリース・挑戦" },
+  { emoji: "🧪", label: "検証・実験" },
+  { emoji: "🔧", label: "設定・ツール" },
+  { emoji: "📚", label: "学習・まとめ" },
+  { emoji: "⚡", label: "効率化" },
+  { emoji: "🔒", label: "セキュリティ" }
+];
+
+let rl;
+
+function getReadline() {
+  if (!rl) {
+    rl = createInterface({ input, output });
+  }
+
+  return rl;
+}
+
+function closeReadline() {
+  if (rl) {
+    rl.close();
+    rl = undefined;
+  }
+}
+
+function normalizeSlug(value) {
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50);
+}
+
+function normalizeTopics(value) {
+  return value
+    .split(",")
+    .map((topic) => topic.trim())
+    .filter(Boolean);
+}
+
+function parseTopics(value) {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  if (trimmed.startsWith("[")) {
+    try {
+      const topics = JSON.parse(trimmed);
+      if (!Array.isArray(topics)) {
+        throw new Error("topics must be an array");
+      }
+
+      if (!topics.every((topic) => typeof topic === "string")) {
+        throw new Error("topics must contain only strings");
+      }
+
+      return topics.map((topic) => topic.trim()).filter(Boolean);
+    } catch {
+      throw new Error(
+        `topics（記事に関連する言語や技術）を配列で指定してください。例）["react", "javascript"]`
+      );
+    }
+  }
+
+  return normalizeTopics(trimmed);
+}
+
+function validateTopics(topics) {
+  if (topics.length === 0) {
+    return "topicsは1つ以上入力してください。例）[\"react\", \"javascript\"]";
+  }
+
+  if (topics.length > 5) {
+    return "topicsは5つまで入力してください。";
+  }
+
+  if (!topics.every((topic) => typeof topic === "string" && topic.trim())) {
+    return `topics（記事に関連する言語や技術）を配列で指定してください。例）["react", "javascript"]`;
+  }
+
+  if (topics.some((topic) => topic.includes("、"))) {
+    return "topicsをカンマ区切りで入力する場合は、半角カンマ「,」を使ってください。例）react,javascript";
+  }
+
+  return null;
+}
+
+function quoteYaml(value) {
+  return JSON.stringify(value);
+}
+
+function formatTopics(topics) {
+  if (topics.length === 0) {
+    return "[]";
+  }
+
+  return `[${topics.map(quoteYaml).join(", ")}]`;
+}
+
+function timestampSlug() {
+  const now = new Date();
+  const pad = (value) => String(value).padStart(2, "0");
+
+  return [
+    now.getFullYear(),
+    pad(now.getMonth() + 1),
+    pad(now.getDate()),
+    "-",
+    pad(now.getHours()),
+    pad(now.getMinutes()),
+    pad(now.getSeconds())
+  ].join("");
+}
+
+function isNodeError(error, code) {
+  return error && typeof error === "object" && "code" in error && error.code === code;
+}
+
+async function ask(question, defaultValue = "") {
+  const suffix = defaultValue ? ` (${defaultValue})` : "";
+  const answer = await getReadline().question(`${question}${suffix}: `);
+  return answer.trim() || defaultValue;
+}
+
+async function askRequired(question) {
+  while (true) {
+    const answer = await ask(question);
+    if (answer) {
+      return answer;
+    }
+
+    console.log("必須項目です。入力してください。");
+  }
+}
+
+async function askType() {
+  while (true) {
+    const answer = await ask("種類 tech/idea", DEFAULT_TYPE);
+    if (answer === "tech" || answer === "idea") {
+      return answer;
+    }
+
+    console.log("tech または idea を入力してください。");
+  }
+}
+
+async function askEmoji() {
+  console.log("emojiを番号で選んでください。");
+  EMOJI_CHOICES.forEach((choice, index) => {
+    console.log(`${index + 1}. ${choice.label} ${choice.emoji}`);
+  });
+
+  while (true) {
+    const answer = await ask("emoji番号", "1");
+    const index = Number.parseInt(answer, 10) - 1;
+
+    if (EMOJI_CHOICES[index]) {
+      return EMOJI_CHOICES[index].emoji;
+    }
+
+    console.log(`1〜${EMOJI_CHOICES.length} の番号を入力してください。`);
+  }
+}
+
+async function askTopics() {
+  while (true) {
+    const answer = await ask("topics 配列またはカンマ区切り", `["zenn"]`);
+
+    try {
+      const topics = parseTopics(answer);
+      const error = validateTopics(topics);
+
+      if (!error) {
+        return topics;
+      }
+
+      console.log(error);
+    } catch (error) {
+      console.log(error instanceof Error ? error.message : error);
+    }
+  }
+}
+
+async function askPublished() {
+  const answer = await ask("公開する？ y/N", "N");
+  return ["y", "yes"].includes(answer.toLowerCase());
+}
+
+function buildArticle({ title, emoji, type, topics, published, summary }) {
+  const body = summary
+    ? `\n${summary}\n\n## はじめに\n\n\n## 本文\n\n\n## まとめ\n\n`
+    : "\n## はじめに\n\n\n## 本文\n\n\n## まとめ\n\n";
+
+  return `---
+title: ${quoteYaml(title)}
+emoji: ${quoteYaml(emoji)}
+type: ${quoteYaml(type)}
+topics: ${formatTopics(topics)}
+published: ${published}
+---
+${body}`;
+}
+
+async function writeUniqueArticle(slug, article, articleDir = ARTICLE_DIR) {
+  await mkdir(articleDir, { recursive: true });
+
+  let candidate = slug;
+  let index = 2;
+
+  while (true) {
+    const articlePath = path.join(articleDir, `${candidate}.md`);
+
+    try {
+      await writeFile(articlePath, article, { flag: "wx" });
+
+      return {
+        articlePath,
+        articleSlug: candidate
+      };
+    } catch (error) {
+      if (!isNodeError(error, "EEXIST")) {
+        throw error;
+      }
+
+      candidate = `${slug}-${index}`;
+      index += 1;
+    }
+  }
+}
+
+function waitForServer({ host, port, timeoutMs = 15000 }) {
+  const startedAt = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const retry = () => {
+      const socket = net.createConnection({ host, port });
+
+      socket.once("connect", () => {
+        socket.end();
+        resolve();
+      });
+
+      socket.once("error", () => {
+        socket.destroy();
+
+        if (Date.now() - startedAt > timeoutMs) {
+          reject(new Error(`プレビューサーバーに接続できませんでした: http://${host}:${port}`));
+          return;
+        }
+
+        setTimeout(retry, 300);
+      });
+    };
+
+    retry();
+  });
+}
+
+function openBrowser(url) {
+  const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  const child = spawn(opener, args, {
+    detached: true,
+    stdio: "ignore"
+  });
+
+  child.unref();
+}
+
+async function startPreview(articleSlug) {
+  const articleUrl = `http://${PREVIEW_HOST}:${PREVIEW_PORT}/articles/${articleSlug}`;
+
+  console.log("\nZenn previewを起動します。終了するときは Ctrl+C を押してください。");
+
+  const preview = spawn("npx", ["zenn", "preview", "--port", String(PREVIEW_PORT)], {
+    stdio: "inherit"
+  });
+
+  try {
+    await waitForServer({ host: PREVIEW_HOST, port: PREVIEW_PORT });
+    openBrowser(articleUrl);
+    console.log(`記事を開きました: ${articleUrl}`);
+  } catch (error) {
+    preview.kill("SIGTERM");
+    throw error;
+  }
+
+  preview.on("exit", (code, signal) => {
+    if (signal) {
+      process.exitCode = 0;
+      return;
+    }
+
+    process.exitCode = code ?? 0;
+  });
+}
+
+async function main() {
+  console.log("Zenn記事を作成します。空欄はおすすめ値で進められます。\n");
+
+  const title = await askRequired("タイトル");
+  const defaultSlug = normalizeSlug(title) || `article-${timestampSlug()}`;
+  const slug = normalizeSlug(await ask("slug", defaultSlug)) || defaultSlug;
+  const emoji = await askEmoji();
+  const type = await askType();
+  const topics = await askTopics();
+  const published = await askPublished();
+  const summary = await ask("概要");
+
+  const article = buildArticle({ title, emoji, type, topics, published, summary });
+  const { articlePath, articleSlug } = await writeUniqueArticle(slug, article);
+
+  console.log(`\n作成しました: ${articlePath}`);
+  closeReadline();
+
+  await startPreview(articleSlug);
+}
+
+export {
+  buildArticle,
+  formatTopics,
+  normalizeSlug,
+  normalizeTopics,
+  parseTopics,
+  validateTopics,
+  writeUniqueArticle
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    closeReadline();
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/tests/create-article.test.mjs
+++ b/tests/create-article.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildArticle,
+  normalizeSlug,
+  parseTopics,
+  validateTopics,
+  writeUniqueArticle
+} from "../scripts/create-article.mjs";
+
+test("normalizeSlug converts title-like text into a lowercase slug", () => {
+  assert.equal(normalizeSlug(" Hello_World!! 2026 "), "hello-world-2026");
+});
+
+test("normalizeSlug returns an empty slug when the title has no supported characters", () => {
+  assert.equal(normalizeSlug("テスト技法の使い分け"), "");
+});
+
+test("parseTopics accepts comma-separated topics", () => {
+  assert.deepEqual(parseTopics("react, javascript, zenn"), ["react", "javascript", "zenn"]);
+});
+
+test("parseTopics accepts a JSON array of topics", () => {
+  assert.deepEqual(parseTopics(`["react", " javascript ", "zenn"]`), ["react", "javascript", "zenn"]);
+});
+
+test("parseTopics rejects JSON arrays containing non-string values", () => {
+  assert.throws(
+    () => parseTopics(`["react", 123]`),
+    /topics（記事に関連する言語や技術）を配列で指定してください/
+  );
+});
+
+test("validateTopics rejects empty and oversized topic lists", () => {
+  assert.match(validateTopics([]), /1つ以上/);
+  assert.match(validateTopics(["a", "b", "c", "d", "e", "f"]), /5つまで/);
+});
+
+test("validateTopics rejects Japanese comma separators", () => {
+  assert.match(validateTopics(["あああ、あああ"]), /半角カンマ/);
+});
+
+test("buildArticle renders frontmatter and body template", () => {
+  const article = buildArticle({
+    title: "CLIを作る",
+    emoji: "📝",
+    type: "tech",
+    topics: ["zenn", "cli"],
+    published: false,
+    summary: "概要です。"
+  });
+
+  assert.equal(
+    article,
+    `---
+title: "CLIを作る"
+emoji: "📝"
+type: "tech"
+topics: ["zenn", "cli"]
+published: false
+---
+
+概要です。
+
+## はじめに
+
+
+## 本文
+
+
+## まとめ
+
+`
+  );
+});
+
+test("writeUniqueArticle writes to the first available slug", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "create-article-test-"));
+  const articleDir = path.join(directory, "articles");
+
+  try {
+    await writeUniqueArticle("sample", "existing", articleDir);
+    const result = await writeUniqueArticle("sample", "new article", articleDir);
+
+    assert.deepEqual(result, {
+      articlePath: path.join(articleDir, "sample-2.md"),
+      articleSlug: "sample-2"
+    });
+    assert.equal(await readFile(result.articlePath, "utf8"), "new article");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("writeUniqueArticle does not overwrite existing files", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "create-article-test-"));
+  const articleDir = path.join(directory, "articles");
+
+  try {
+    await writeUniqueArticle("sample", "first", articleDir);
+    await writeUniqueArticle("sample", "second", articleDir);
+
+    assert.equal(await readFile(path.join(articleDir, "sample.md"), "utf8"), "first");
+    assert.equal(await readFile(path.join(articleDir, "sample-2.md"), "utf8"), "second");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要

対話式で Zenn 記事の Markdown ファイルを作成し、そのまま preview まで起動できる CLI を追加しました。

Closes #2

## 変更内容

- `scripts/create-article.mjs` を追加
  - タイトル、slug、emoji、type、topics、公開設定、概要を対話式に入力できます
  - emoji は番号選択式にしました
  - topics はカンマ区切りと JSON 配列の両方を受け付けます
  - 日本語読点 `、` を区切り文字として入力した場合は、半角カンマ `,` を使うようにエラー表示します
  - 既存ファイルがある場合は `slug-2`, `slug-3` のように採番し、上書きしません
  - `writeFile(..., { flag: "wx" })` に寄せて、事前 `existsSync` チェック由来の競合を避けました
  - preview 起動待ちに失敗した場合は、起動済みの preview プロセスを `SIGTERM` で終了します
- `package.json` に CLI 実行用 script を追加
  - `npm run article:new`
  - `npm run new`
  - `npm test`
- `tests/create-article.test.mjs` を追加
  - slug 正規化
  - topics の parse / validate
  - 日本語読点の拒否
  - 記事テンプレート生成
  - 同名記事の採番作成
  - 既存ファイルを上書きしないこと
- README に対話式 CLI の使い方を追記

## 設計メモ

- CLI ファイルは import 時に `main()` が起動しないようにし、テスト対象の関数を export しています
- `writeUniqueArticle(slug, article, articleDir = ARTICLE_DIR)` として、テストでは `process.chdir()` を使わず任意の出力先を渡せるようにしました
- Zenn 公式 CLI の slug デフォルトはランダム生成なので、現在のタイトル由来 slug 生成は今後見直し候補です

## 検証

```bash
npm test
node --check scripts/create-article.mjs
node --check tests/create-article.test.mjs
```

`npm test` は 10 件すべて通過しています。