### PR TITLE
Generate article slugs from readable prefix and random suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm run article:new
 質問に答えると、`articles/`配下にZenn用のMarkdownファイルが作成されます。
 emojiは番号で選択でき、記事作成後は自動で`npx zenn preview`が起動して、作成した記事ページがブラウザで開きます。
 Zenn CLI固有のコマンドやオプションは、このラッパーCLIの内側に隠しています。
+slugは先頭部分だけを入力し、末尾には自動生成された文字列が付きます。
+たとえば`testing-cli`と入力すると、`testing-cli-a1b2c3d4e5f6`のようなファイル名になります。
 
 ## 記事の雛形からサーバーの起動まで実行
 

--- a/scripts/create-article.mjs
+++ b/scripts/create-article.mjs
@@ -2,6 +2,7 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import net from "node:net";
 import path from "node:path";
 import process from "node:process";
@@ -13,6 +14,8 @@ const ARTICLE_DIR = "articles";
 const DEFAULT_TYPE = "tech";
 const PREVIEW_PORT = 8000;
 const PREVIEW_HOST = "localhost";
+const MAX_SLUG_LENGTH = 50;
+const DEFAULT_SLUG_PREFIX = "article";
 const EMOJI_CHOICES = [
   { emoji: "📝", label: "メモ・記事" },
   { emoji: "💡", label: "アイデア" },
@@ -50,7 +53,19 @@ function normalizeSlug(value) {
     .replace(/[\s_]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")
-    .slice(0, 50);
+    .slice(0, MAX_SLUG_LENGTH);
+}
+
+function generateSlugSuffix() {
+  return randomBytes(7).toString("hex");
+}
+
+function buildArticleSlug(prefix, suffix = generateSlugSuffix()) {
+  const normalizedSuffix = normalizeSlug(suffix);
+  const maxPrefixLength = MAX_SLUG_LENGTH - normalizedSuffix.length - 1;
+  const normalizedPrefix = normalizeSlug(prefix).slice(0, maxPrefixLength).replace(/-$/g, "") || DEFAULT_SLUG_PREFIX;
+
+  return `${normalizedPrefix}-${normalizedSuffix}`;
 }
 
 function normalizeTopics(value) {
@@ -119,21 +134,6 @@ function formatTopics(topics) {
   }
 
   return `[${topics.map(quoteYaml).join(", ")}]`;
-}
-
-function timestampSlug() {
-  const now = new Date();
-  const pad = (value) => String(value).padStart(2, "0");
-
-  return [
-    now.getFullYear(),
-    pad(now.getMonth() + 1),
-    pad(now.getDate()),
-    "-",
-    pad(now.getHours()),
-    pad(now.getMinutes()),
-    pad(now.getSeconds())
-  ].join("");
 }
 
 function isNodeError(error, code) {
@@ -323,8 +323,9 @@ async function main() {
   console.log("Zenn記事を作成します。空欄はおすすめ値で進められます。\n");
 
   const title = await askRequired("タイトル");
-  const defaultSlug = normalizeSlug(title) || `article-${timestampSlug()}`;
-  const slug = normalizeSlug(await ask("slug", defaultSlug)) || defaultSlug;
+  const defaultSlugPrefix = normalizeSlug(title) || DEFAULT_SLUG_PREFIX;
+  const slugPrefix = await ask("slug先頭", defaultSlugPrefix);
+  const slug = buildArticleSlug(slugPrefix);
   const emoji = await askEmoji();
   const type = await askType();
   const topics = await askTopics();
@@ -335,6 +336,7 @@ async function main() {
   const { articlePath, articleSlug } = await writeUniqueArticle(slug, article);
 
   console.log(`\n作成しました: ${articlePath}`);
+  console.log(`slug: ${articleSlug}`);
   closeReadline();
 
   await startPreview(articleSlug);
@@ -342,6 +344,7 @@ async function main() {
 
 export {
   buildArticle,
+  buildArticleSlug,
   formatTopics,
   normalizeSlug,
   normalizeTopics,

--- a/tests/create-article.test.mjs
+++ b/tests/create-article.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   buildArticle,
+  buildArticleSlug,
   normalizeSlug,
   parseTopics,
   validateTopics,
@@ -18,6 +19,25 @@ test("normalizeSlug converts title-like text into a lowercase slug", () => {
 
 test("normalizeSlug returns an empty slug when the title has no supported characters", () => {
   assert.equal(normalizeSlug("テスト技法の使い分け"), "");
+});
+
+test("buildArticleSlug appends an auto-generated suffix to a readable prefix", () => {
+  assert.equal(buildArticleSlug("TDD CLI", "a1b2c3d4e5f6"), "tdd-cli-a1b2c3d4e5f6");
+});
+
+test("buildArticleSlug generates a random suffix when omitted", () => {
+  assert.match(buildArticleSlug("TDD CLI"), /^tdd-cli-[a-f0-9]{14}$/);
+});
+
+test("buildArticleSlug keeps the slug within 50 characters", () => {
+  const slug = buildArticleSlug("this is a very long article slug prefix for local readability", "a1b2c3d4e5f6");
+
+  assert.equal(slug.length, 50);
+  assert.match(slug, /-a1b2c3d4e5f6$/);
+});
+
+test("buildArticleSlug uses a fallback prefix when the readable prefix is empty", () => {
+  assert.equal(buildArticleSlug("テスト技法の使い分け", "a1b2c3d4e5f6"), "article-a1b2c3d4e5f6");
 });
 
 test("parseTopics accepts comma-separated topics", () => {


### PR DESCRIPTION
## 概要

対話式 Zenn 記事作成 CLI の slug 生成を、記事内容が分かる prefix と自動生成 suffix の組み合わせに変更しました。

Closes #4

## 変更内容

- `buildArticleSlug()` を追加
  - 入力した prefix を既存の slug 正規化ルールで整形します
  - 末尾に 14 桁のランダム hex suffix を付けます
  - 例: `testing-cli-a1b2c3d4e5f6`
- CLI の入力を `slug` 直接指定から `slug先頭` に変更
  - タイトル由来の prefix をデフォルト表示します
  - 日本語タイトルなどで prefix が空になる場合は `article` に fallback します
- slug 全体が Zenn の上限である 50 文字以内になるよう prefix を切り詰めます
- 作成後に生成された slug を表示します
- README に新しい slug 生成ルールを追記しました
- slug 生成のテストを追加しました

## 検証

```bash
npm test
node --check scripts/create-article.mjs
node --check tests/create-article.test.mjs
```

`npm test` は 14 件すべて通過しています。